### PR TITLE
define empty defines as "1" instead of ""

### DIFF
--- a/src/Distribution/HaskellSuite/Cabal.hs
+++ b/src/Distribution/HaskellSuite/Cabal.hs
@@ -220,7 +220,7 @@ cppOptsParser = appEndo <$> allMod <*> pure defaultCpphsOptions
           def :: (String, String)
           def =
             case span (/= '=') str of
-              (_, []) -> (str, "")
+              (_, []) -> (str, "1")
               (sym, _:var) -> (sym, var)
           in Endo $ \opts -> opts { defines = def : defines opts }
 


### PR DESCRIPTION
cpphs chokes when given for example a pair ("UNIX","") as a define.
